### PR TITLE
add script for preparing release-notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,9 @@ This repository is a collection of tools/scripts used by the GlusterFS release m
 ./close-bugs.sh <file-with-bugs-to-be-closed> <version-string-for-current-release> <url-to-mailing-list-announcement>
   ```
 
-  We'll add a script to generate the bugs list file soon.
+- `release_notes.sh`
+  This script is used to generate the release notes for a release. Run it as,
+  ```
+./release_notes.sh <previous version released> <current version to be released> <path to glusterfs repository>
+  ```
 

--- a/release_notes.sh
+++ b/release_notes.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+
+function generate_release_notes ()
+{
+    orig_version=$1
+    latest_version=$2
+    repo=$3;
+
+    cd $3;
+
+for i in $(git log $1..$2 | grep BUG | grep -v ">" | cut -f 2 -d ":") ;do
+    echo -n "$i - " >> /tmp/release_notes && echo `bugzilla query -b $i | sed -e 's/.*\ -\ //'` >> /tmp/release_notes;
+done
+
+# the below style of using awk can also be used as it acts as the logical cut with delimiter being ' - '
+#for i in $(git log $1..$2 | grep BUG | grep -v ">" | cut -f 2 -d ":") ;do
+#    echo -n "$i - " >> /tmp/release_notes && echo `bugzilla query -b $i | awk -F' - ' '{print $3'}` >> /tmp/release_notes;
+#done
+}
+
+function main ()
+{
+    generate_release_notes $1 $2 $3;
+}
+
+main "$@"


### PR DESCRIPTION
The script takes, previous version, the current version to be released, and the
path to the glusterfs repository as the arguments.

Signed-off-by: Raghavendra Bhat raghavendra@redhat.com
