### PR TITLE
Add scripts for working with the CentOS Community Build system

### DIFF
--- a/cbs-build.sh
+++ b/cbs-build.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+#
+# Build packages in the CentOS Community Build System (CBS).
+#
+# This script assumes:
+# - you have a working 'cbs' command, and the required certs
+# - the working-dir is a git repository of git@github.com:CentOS-Storage-SIG/glusterfs.git
+# - fedpkg is useable for EPEL packages (TODO: replace with SIG buildroot)
+
+check_cbs() {
+	cbs moshimoshi > /dev/null
+}
+
+# build a src.rpm and write the path to stdout
+local_get_srpm() {
+	local OS=${1}
+	fedpkg --release=${OS} srpm 2>/dev/null | awk '/^Wrote/ {print $2}'
+}
+
+local_mockbuild() {
+	local OS=${1}
+	fedpkg --release=${OS} mockbuild
+}
+
+# A branch has a format like 'sig-storage7-gluster-38'
+GIT_BRANCH=$(git describe --contains --all HEAD)
+PREFIX='sig-storage'
+OS=$(sed -e "s/^${PREFIX}//" -e "s/-.*//" <<< "${GIT_BRANCH}")
+PROJECT=$(cut -d - -f 3 <<< "${GIT_BRANCH}")
+VERSION=$(cut -d - -f 4 <<< "${GIT_BRANCH}")
+
+# TODO: do some validation of the git repo, branch and parsed values
+
+# fail on an error
+set -e
+
+# run very verbose
+set -x
+
+# check if the 'cbs' command works
+check_cbs
+
+# do a local mock build
+local_mockbuild el${OS}
+
+# create the src.rpm (well, re-create it and get the path)
+SRPM=$(local_get_srpm el${OS})
+test -n ${SRPM}
+
+# do a scratch build in the CBS
+BUILDTARGET_PREFIX='storage'
+cbs build --scratch ${BUILDTARGET_PREFIX}${OS}-${PROJECT}-${VERSION}-el${OS} ${SRPM}
+
+# TODO: fail in case the git repo is dirty ('git status --short'?)
+GIT_REPO='git@github.com:CentOS-Storage-SIG/glusterfs.git'
+GIT_REMOTE=$(git remote -v | grep -m 1 -w "${GIT_REMOTE}" | cut -f 1)
+test -n ${GIT_REMOTE}
+git push ${GIT_REMOTE} ${GIT_BRANCH}
+
+# scratch build worked, build for real
+cbs build ${BUILDTARGET_PREFIX}${OS}-${PROJECT}-${VERSION}-el${OS} ${SRPM}
+
+# build finished successfully, mark the build for testing
+NVR=$(basename ${SRPM} .src.rpm)
+test -n ${NVR}
+cbs tag-pkg ${BUILDTARGET_PREFIX}${OS}-${PROJECT}-${VERSION}-testing ${NVR}

--- a/cbs-release.sh
+++ b/cbs-release.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+#
+# Promote builds from testing to release in the CentOS Community Build System
+# (CBS).
+#
+# This script assumes:
+# - you have a working 'cbs' command, and the required certs
+# - you pass a build/NVR on the cmdline (like 'glusterfs-3.8.9-1.el6')
+
+check_cbs() {
+	cbs moshimoshi > /dev/null
+}
+
+# print the tags of a build to stdout
+cbs_get_tags() {
+	local NVR=${1}
+
+	cbs buildinfo ${NVR} | grep ^Tags | cut -d ' ' -f 2-
+}
+
+if [ -z "${1}" -o "${1}" = '-h' -o "${1}" = '--help' ]
+then
+	echo "Usage: ${0} <name-version-release.dist>"
+	exit
+fi
+NVR=${1}
+
+# fail on an error
+set -e
+
+# check if the 'cbs' command works
+check_cbs
+
+# find the build and verify the tags are not empty
+TAGS=$(cbs_get_tags ${NVR})
+if [ -z "${TAGS}" ]
+then
+	echo "Build ${NVR} could not be found."
+	exit
+fi
+
+PROMOTE_BUILD=''
+for TAG in ${TAGS}
+do
+	PREFIX=$(cut -d - -f 1 <<< "${TAG}")
+	PROJECT=$(cut -d - -f 2 <<< "${TAG}")
+	VERSION=$(cut -d - -f 3 <<< "${TAG}")
+	STATE=$(sed 's/.*-//' <<< "${TAG}")
+
+	case "${STATE}" in
+	'testing')
+		# build is in testing, it may be promoted
+		PROMOTE_BUILD=1
+		;;
+	'release')
+		# build is released already, nothing to do
+		echo "Build ${NVR} has been tagged in -release already."
+		exit
+		;;
+	*)
+		# skip, we don't care about this tag
+		;;
+	esac
+done
+
+if [ -n "${PROMOTE_BUILD}" ]
+then
+	cbs tag-pkg ${PREFIX}-${PROJECT}-${VERSION}-release ${NVR}
+else
+	echo "Build ${NVR} is not in -testing yet, not promoting to -release."
+fi


### PR DESCRIPTION
cbs-build.sh:
  script for building packages and tagging them in the testing
  repository.

cbs-release.sh:
  takes a build and tags it for release.

These scripts have not been tested extensively, they are more of a
collection of commands so that others can do CentOS Storage SIG builds
as well.

Signed-off-by: Niels de Vos <ndevos@redhat.com>