### PR TITLE
close-bugs-eol: new script to close bugs with an EOL message

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,25 @@ This repository is a collection of tools/scripts used by the GlusterFS release m
 
 - `close-bugs.sh`
   This script is used to close bugs after a release. Run it as,
+
   ```
-./close-bugs.sh <file-with-bugs-to-be-closed> <version-string-for-current-release> <url-to-mailing-list-announcement>
+  ./close-bugs.sh <file-with-bugs-to-be-closed> <version-string-for-current-release> <url-to-mailing-list-announcement>
+  ```
+
+- `close-bugs-eol.sh`
+  Use this script to close bugs when a version is End-Of-Life. Modify the `3.8` in the example commands:
+
+  ```
+  bugzilla query --from-url='https://bugzilla.redhat.com/buglist.cgi?f1=version&f2=bug_status&o1=regexp&o2=notequals&product=GlusterFS&v1=^3.8&v2=CLOSED' \
+                 --ids > /tmp/bugs_to_close.txt
+
+  ./close-bugs-eol.sh /tmp/bugs_to_close.txt 3.8
   ```
 
 - `release_notes.sh`
   This script is used to generate the release notes for a release. Run it as,
+
   ```
-./release_notes.sh <previous version released> <current version to be released> <path to glusterfs repository>
+  ./release_notes.sh <previous version released> <current version to be released> <path to glusterfs repository>
   ```
 

--- a/close-bugs-eol.sh
+++ b/close-bugs-eol.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+#
+# Example usage:
+# 1. list all bugs that are open (against 3.8):
+#    https://bugzilla.redhat.com/buglist.cgi?f1=version&f2=bug_status&o1=regexp&o2=notequals&product=GlusterFS&v1=^3.8&v2=CLOSED
+# 
+# 2. create a file with all BZs (numbers only):
+#    $ bugzilla query --from-url='https://bugzilla.redhat.com/buglist.cgi?f1=version&f2=bug_status&o1=regexp&o2=notequals&product=GlusterFS&v1=^3.8&v2=CLOSED' \
+#                     --ids > /tmp/bugs_to_close.txt
+# 
+# 3. close the bugs:
+#    $ ./close-bugs-eol.sh /tmp/bugs_to_close.txt 3.8
+# 
+
+declare BUGSLIST VERSION
+
+if [ "x$DRY_RUN" != "x" ]; then
+  DR="echo"
+fi
+
+check_for_command()
+{
+  env bugzilla --version >/dev/null 2>&1
+  if [ $? -ne 0 ]; then
+    echo "`bugzilla` command is missing"
+    echo "Install `python-bugzilla` before running this script again"
+    exit 1
+  fi
+}
+
+close_bugs()
+{
+	COMMENT="This bug is getting closed because the ${VERSION} version is marked End-Of-Life. There will be no further updates to this version. Please open a new bug against a version that still receives bugfixes if you are still facing this issue in a more current release."
+
+	xargs -n 8 ${DR} bugzilla modify \
+		--status=CLOSED \
+		--close=EOL \
+		--comment="${COMMENT}" ${@}
+}
+
+check_for_command
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <file-with-bugs-to-be-closed> <eol-version>"
+  exit 1
+fi
+
+BUGSLIST=$1
+VERSION=$2
+
+cat $BUGSLIST | close_bugs


### PR DESCRIPTION
Just like we're closing bugs that have their patches merged in a
release, we should close bugs that have been reported against a version
that is EOL.

The usage is the same as `close-bugs.sh` in that the first argument is a
file listing the bugs. A normal execution therefore looks like this:

1. list all bugs that are open (against 3.8):
   https://bugzilla.redhat.com/buglist.cgi?f1=version&f2=bug_status&o1=regexp&o2=notequals&product=GlusterFS&v1=^3.8&v2=CLOSED

2. create a file with all BZs (numbers only):
   $ bugzilla query --from-url='https://bugzilla.redhat.com/buglist.cgi?f1=version&f2=bug_status&o1=regexp&o2=notequals&product=GlusterFS&v1=^3.8&v2=CLOSED' \
                    --ids > /tmp/bugs_to_close.txt

3. close the bugs:
   $ ./close-bugs-eol.sh /tmp/bugs_to_close.txt 3.8

Signed-off-by: Niels de Vos <ndevos@redhat.com>