### PR TITLE
Update readme to show the commands in the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,21 @@
 
 This repository is a collection of tools/scripts used by the GlusterFS release managers to do GlusterFS releases.
 
+### Prerequisite
+
+Bugzilla package needs to be installed on the machine where the script will be run.
+
 ### Scripts
 
 - `close-bugs.sh`
   This script is used to close bugs after a release. Run it as,
   ```
-./close-bugs.sh <file-with-bugs-to-be-closed> <version-string-for-current-release> <url-to-mailing-list-announcement>
+        ./close-bugs.sh <file-with-bugs-to-be-closed> <version-string-for-current-release> <url-to-mailing-list-announcement>
   ```
 
 - `release_notes.sh`
   This script is used to generate the release notes for a release. Run it as,
   ```
-./release_notes.sh <previous version released> <current version to be released> <path to glusterfs repository>
+        ./release_notes.sh <previous version released> <current version to be released> <path to glusterfs repository>
   ```
 


### PR DESCRIPTION
As of now the readme page on the github doesn't show the
commands due to a formatting issue. This has been fixed.

The requirement for the bugzilla package hasn't been
mentioned anywhere. The script doesn't work without it and
the error message isn't good enough to ask the user to install it.
Hence have added it as a prerequisite in the readme.

Signed-off-by: hari gowtham <hgowtham@redhat.com>